### PR TITLE
fix: reload kong instead of restart after cert update

### DIFF
--- a/api/cert.go
+++ b/api/cert.go
@@ -80,7 +80,7 @@ func (a *API) UpdateCert(w http.ResponseWriter, r *http.Request) error {
 	// restart kong to load the new config
 	// need to do command as goroutine because adminapi gets killed and can't respond
 	go func() {
-		cmd := exec.Command("sudo", "systemctl", "restart", "kong.service")
+		cmd := exec.Command("sudo", "/usr/local/bin/kong", "reload")
 		_, err = cmd.Output()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, err.Error())


### PR DESCRIPTION
fixes https://github.com/supabase/supabase-admin-api/issues/37

