### PR TITLE
cleaner way of reloading kong

### DIFF
--- a/api/cert.go
+++ b/api/cert.go
@@ -80,7 +80,7 @@ func (a *API) UpdateCert(w http.ResponseWriter, r *http.Request) error {
 	// restart kong to load the new config
 	// need to do command as goroutine because adminapi gets killed and can't respond
 	go func() {
-		cmd := exec.Command("sudo", "/usr/local/bin/kong", "reload")
+		cmd := exec.Command("sudo", "systemctl", "reload", "kong")
 		_, err = cmd.Output()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, err.Error())


### PR DESCRIPTION
use systemctl reload to reload kong. Cleaner since it uses systemctl and doesn't bypass it. 