### PR TITLE
fix: kong reload command must match sudoers file

### DIFF
--- a/api/cert.go
+++ b/api/cert.go
@@ -80,7 +80,7 @@ func (a *API) UpdateCert(w http.ResponseWriter, r *http.Request) error {
 	// restart kong to load the new config
 	// need to do command as goroutine because adminapi gets killed and can't respond
 	go func() {
-		cmd := exec.Command("sudo", "systemctl", "reload", "kong")
+		cmd := exec.Command("sudo", "systemctl", "reload", "kong.service")
 		_, err = cmd.Output()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, err.Error())


### PR DESCRIPTION
must match this line https://github.com/supabase/kps/blob/c26605f7c514e2e4fb05ad4186da629b617e85c8/ansible/tasks/setup-admin-api.yml#L19
