### PR TITLE
fix: get host and port as env variables

### DIFF
--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -16,10 +18,19 @@ var serveCmd = cobra.Command{
 	},
 }
 
+func getEnv(key, fallback string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return fallback
+	}
+	return value
+}
+
 func serve() {
 	config := api.Config{}
-	config.Host = "localhost"
-	config.Port = 8085
+	config.Host = getEnv("HOST", "localhost")
+	port, _ := strconv.Atoi(getEnv("PORT", "8085"))
+	config.Port = port
 	config.Endpoint = "ENDPOINT"
 	config.RequestIDHeader = "REQUEST_ID_HEADER"
 	config.ExternalURL = "API_EXTERNAL_URL"


### PR DESCRIPTION
Takes in host and port to start the server from env variables. 