### PR TITLE
feat: monitor gotrue and postgrest

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -24,12 +24,12 @@ const (
 
 // Config is the main API config
 type Config struct {
-	Host                   string `default:"localhost"`
-	Port                   int    `default:"8085"`
-	JwtSecret              string `required:"true" split_words:"true"`
-	MetricCollectors       string `required:"false" default:"meminfo,loadavg,cpu"`
-	GoTrueLivenessEndpoint string `required:"false" default:"http://localhost:9999/liveness"`
-	PostgrestEndpoint      string `required:"false" default:"http://localhost:3000/"`
+	Host                 string `default:"localhost"`
+	Port                 int    `default:"8085"`
+	JwtSecret            string `required:"true" split_words:"true"`
+	MetricCollectors     string `required:"false" default:"meminfo,loadavg,cpu"`
+	GotrueHealthEndpoint string `required:"false" default:"http://localhost:9999/health"`
+	PostgrestEndpoint    string `required:"false" default:"http://localhost:3000/"`
 }
 
 func (c *Config) GetEnabledCollectors() []string {
@@ -93,7 +93,7 @@ func NewAPI(config *Config) *API {
 // NewAPIWithVersion creates a new REST API using the specified version
 func NewAPIWithVersion(config *Config, version string) *API {
 	api := &API{config: config, version: version}
-	metrics, err := NewMetrics(config.GetEnabledCollectors(), config.GoTrueLivenessEndpoint, config.PostgrestEndpoint); if err != nil {
+	metrics, err := NewMetrics(config.GetEnabledCollectors(), config.GotrueHealthEndpoint, config.PostgrestEndpoint); if err != nil {
 		panic(fmt.Sprintf("Couldn't initialize metrics: %+v", err))
 	}
 

--- a/api/api.go
+++ b/api/api.go
@@ -24,10 +24,12 @@ const (
 
 // Config is the main API config
 type Config struct {
-	Host             string `default:"localhost"`
-	Port             int    `default:"8085"`
-	JwtSecret        string `required:"true" split_words:"true"`
-	MetricCollectors string `required:"false" default:"meminfo,loadavg,cpu"`
+	Host                   string `default:"localhost"`
+	Port                   int    `default:"8085"`
+	JwtSecret              string `required:"true" split_words:"true"`
+	MetricCollectors       string `required:"false" default:"meminfo,loadavg,cpu"`
+	GoTrueLivenessEndpoint string `required:"false" default:"http://localhost:9999/liveness"`
+	PostgrestEndpoint      string `required:"false" default:"http://localhost:3000/"`
 }
 
 func (c *Config) GetEnabledCollectors() []string {
@@ -91,7 +93,7 @@ func NewAPI(config *Config) *API {
 // NewAPIWithVersion creates a new REST API using the specified version
 func NewAPIWithVersion(config *Config, version string) *API {
 	api := &API{config: config, version: version}
-	metrics, err := NewMetrics(config.GetEnabledCollectors()); if err != nil {
+	metrics, err := NewMetrics(config.GetEnabledCollectors(), config.GoTrueLivenessEndpoint, config.PostgrestEndpoint); if err != nil {
 		panic(fmt.Sprintf("Couldn't initialize metrics: %+v", err))
 	}
 

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -35,7 +35,7 @@ func NewMetrics(collectors []string, gotrueUrl string, postgrestUrl string) (*Me
 
 	rtime := metrics.NewRealtimeCollector()
 	gotrue := metrics.NewGotrueCollector(gotrueUrl)
-	postgrest := metrics.NewGotrueCollector(postgrestUrl)
+	postgrest := metrics.NewPostgrestCollector(postgrestUrl)
 	for _, c := range []prometheus.Collector{node, rtime, gotrue, postgrest} {
 		err = registry.Register(c)
 		if err != nil {

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -13,10 +13,10 @@ import (
 )
 
 type Metrics struct {
-	registry      *prometheus.Registry
+	registry *prometheus.Registry
 }
 
-func NewMetrics(collectors []string) (*Metrics, error) {
+func NewMetrics(collectors []string, gotrueUrl string, postgrestUrl string) (*Metrics, error) {
 	registry := prometheus.NewRegistry()
 
 	// the Parse call is a hack to get the collectors in node-exporter to register
@@ -34,7 +34,9 @@ func NewMetrics(collectors []string) (*Metrics, error) {
 	}
 
 	rtime := metrics.NewRealtimeCollector()
-	for _, c := range []prometheus.Collector{node, rtime} {
+	gotrue := metrics.NewGotrueCollector(gotrueUrl)
+	postgrest := metrics.NewGotrueCollector(postgrestUrl)
+	for _, c := range []prometheus.Collector{node, rtime, gotrue, postgrest} {
 		err = registry.Register(c)
 		if err != nil {
 			return nil, err

--- a/api/metrics/gotrue.go
+++ b/api/metrics/gotrue.go
@@ -29,7 +29,7 @@ func (c *GotrueCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *GotrueCollector) Collect(ch chan<- prometheus.Metric) {
 	resp, err := c.client.Get(c.url)
 	status := float64(0)
-	if err != nil && resp != nil && resp.StatusCode == 200 {
+	if err == nil && resp != nil && resp.StatusCode == 200 {
 		status = float64(1)
 	}
 	ch <- prometheus.MustNewConstMetric(c.up, prometheus.GaugeValue, status)

--- a/api/metrics/gotrue.go
+++ b/api/metrics/gotrue.go
@@ -1,0 +1,36 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"net/http"
+	"time"
+)
+
+type GotrueCollector struct {
+	up *prometheus.Desc
+	client *http.Client
+	url string
+}
+
+func NewGotrueCollector(gotrueUrl string) *GotrueCollector {
+	return &GotrueCollector{
+		up: prometheus.NewDesc("gotrue_up", "GoTrue status", nil, nil),
+		client: &http.Client{
+			Timeout: 500 * time.Millisecond,
+		},
+		url: gotrueUrl,
+	}
+}
+
+func (c *GotrueCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.up
+}
+
+func (c *GotrueCollector) Collect(ch chan<- prometheus.Metric) {
+	resp, err := c.client.Get(c.url)
+	status := float64(0)
+	if err != nil && resp != nil && resp.StatusCode == 200 {
+		status = float64(1)
+	}
+	ch <- prometheus.MustNewConstMetric(c.up, prometheus.GaugeValue, status)
+}

--- a/api/metrics/postgrest.go
+++ b/api/metrics/postgrest.go
@@ -1,0 +1,36 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"net/http"
+	"time"
+)
+
+type PostgrestCollector struct {
+	up *prometheus.Desc
+	client *http.Client
+	url string
+}
+
+func NewPostgrestCollector(postgrestUrl string) *PostgrestCollector {
+	return &PostgrestCollector{
+		up: prometheus.NewDesc("postgrest_up", "PostgREST status", nil, nil),
+		client: &http.Client{
+			Timeout: 500 * time.Millisecond,
+		},
+		url: postgrestUrl,
+	}
+}
+
+func (c *PostgrestCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.up
+}
+
+func (c *PostgrestCollector) Collect(ch chan<- prometheus.Metric) {
+	resp, err := c.client.Get(c.url)
+	status := float64(0)
+	if err != nil && resp != nil && resp.StatusCode == 200 {
+		status = float64(1)
+	}
+	ch <- prometheus.MustNewConstMetric(c.up, prometheus.GaugeValue, status)
+}

--- a/api/metrics/postgrest.go
+++ b/api/metrics/postgrest.go
@@ -29,7 +29,7 @@ func (c *PostgrestCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *PostgrestCollector) Collect(ch chan<- prometheus.Metric) {
 	resp, err := c.client.Get(c.url)
 	status := float64(0)
-	if err != nil && resp != nil && resp.StatusCode == 200 {
+	if err == nil && resp != nil && resp.StatusCode == 200 {
 		status = float64(1)
 	}
 	ch <- prometheus.MustNewConstMetric(c.up, prometheus.GaugeValue, status)

--- a/api/metrics/postgrest.go
+++ b/api/metrics/postgrest.go
@@ -27,7 +27,7 @@ func (c *PostgrestCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *PostgrestCollector) Collect(ch chan<- prometheus.Metric) {
-	resp, err := c.client.Get(c.url)
+	resp, err := c.client.Head(c.url)
 	status := float64(0)
 	if err == nil && resp != nil && resp.StatusCode == 200 {
 		status = float64(1)


### PR DESCRIPTION
We've had a couple of instances where gotrue or postgrest would be in an error state. These metrics will allow us to start monitoring them from Prometheus, and either alert or hopefully automatically resolve.