### PR TITLE
Fix release process

### DIFF
--- a/.github/workflows/master_build_release.yml
+++ b/.github/workflows/master_build_release.yml
@@ -28,10 +28,7 @@ jobs:
 
       - name: Release on GitHub
         id: github-release
-        run: npx semantic-release -p        \
-          @semantic-release/commit-analyzer \
-          @semantic-release/github         \
-          @semantic-release/release-notes-generator
+        run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -42,8 +39,6 @@ jobs:
           repo: supabase-admin-api
           excludes: prerelease, draft
 
-      
-
   deploy:
     needs: release
     runs-on: ubuntu-20.04
@@ -52,7 +47,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      
+
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.17.0'

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/github", {
+      successComment: false,
+      releasedLabels: false,
+      failTitle: false,
+      addReleases: false,
+    }]
+  ]
+}

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -35,8 +35,8 @@ func NewMetrics(collectors []string, gotrueUrl string, postgrestUrl string) (*Me
 
 	rtime := metrics.NewRealtimeCollector()
 	gotrue := metrics.NewGotrueCollector(gotrueUrl)
-	// postgrest := metrics.NewPostgrestCollector(postgrestUrl)
-	for _, c := range []prometheus.Collector{node, rtime, gotrue} {
+	postgrest := metrics.NewPostgrestCollector(postgrestUrl)
+	for _, c := range []prometheus.Collector{node, rtime, gotrue, postgrest} {
 		err = registry.Register(c)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Also reverts the change to stop monitoring postgrest, since the monitoring system uses the same endpoint anyway, so the postgres logs would be polluted with this information regardless.